### PR TITLE
Add eltoo onchain example

### DIFF
--- a/lib/contracts/conditional.rb
+++ b/lib/contracts/conditional.rb
@@ -1,0 +1,68 @@
+# Copyright 2024 Kulpreet Singh
+#
+# This file is part of Bitcoin-DSL
+#
+# Bitcoin-DSL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bitcoin-DSL is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bitcoin-DSL. If not, see <https://www.gnu.org/licenses/>.
+
+# frozen_string_literal: false
+
+@alice = key :new
+@bob = key :new
+
+extend_chain to: @alice, num_blocks: 101
+
+@input_tx = spendable_coinbase_for @alice
+
+@conditional_output_script = %(
+OP_IF
+        @alice OP_CHECKSIGVERIFY 10 OP_CSV
+OP_ELSE
+        @bob OP_CHECKSIGVERIFY 10 OP_CSV
+OP_ENDIF
+)
+
+@generate_conditional_output = transaction inputs: [
+                                             {
+                                               tx: @input_tx,
+                                               vout: 0,
+                                               script_sig: 'sig:wpkh(@alice)'
+                                             }
+                                           ],
+                                           outputs: [
+                                             {
+                                               script: @conditional_output_script,
+                                               amount: 49.999.sats
+                                             }
+                                           ]
+@spending_tx = transaction inputs: [
+                             {
+                               tx: @generate_conditional_output,
+                               vout: 0,
+                               script_sig: 'sig:@alice 0x01',
+                               csv: 10
+                             }
+                           ],
+                           outputs: [
+                             {
+                               descriptor: 'wpkh(@alice)',
+                               amount: 49.998.sats
+                             }
+                           ]
+
+broadcast @generate_conditional_output
+confirm transaction: @generate_conditional_output, to: @bob
+
+assert_not_mempool_accept @spending_tx
+extend_chain num_blocks: 10
+assert_mempool_accept @spending_tx

--- a/lib/contracts/lightning/eltoo_onchain.rb
+++ b/lib/contracts/lightning/eltoo_onchain.rb
@@ -35,32 +35,30 @@ OP_ENDIF
 
 transition :setup do
   extend_chain to: @alice, num_blocks: 101
-  @alice_funding_input_tx = spendable_coinbase_for @alice
-end
+  @alice_input_tx = spendable_coinbase_for @alice
 
-transition :alice_creates_funding do
-  @funding_tx = transaction inputs: [
-                              {
-                                tx: @alice_funding_input_tx,
-                                vout: 0,
-                                script_sig: 'sig:_skip'
-                              }
-                            ],
-                            outputs: [
-                              {
-                                script: @update_script,
-                                # descriptor: 'wsh(multi(2,@alice_settlement_key,@bob_settlement_key))',
-                                amount: 49.999.sats
-                              }
-                            ]
-  assert_not_mempool_accept @funding_tx
+  @setup_tx = transaction inputs: [
+                            {
+                              tx: @alice_input_tx,
+                              vout: 0,
+                              script_sig: 'sig:_skip'
+                            }
+                          ],
+                          outputs: [
+                            {
+                              script: @update_script,
+                              # descriptor: 'wsh(multi(2,@alice_settlement_key,@bob_settlement_key))',
+                              amount: 49.999.sats
+                            }
+                          ]
+  assert_not_mempool_accept @setup_tx
 end
 
 transition :bob_creates_settlement do
   # Bob signs a settlement transaction paying agreed amounts to Alice
   @settlement_tx = transaction inputs: [
                                  {
-                                   tx: @funding_tx,
+                                   tx: @setup_tx,
                                    vout: 0,
                                    script_sig: 'sig:multi(_empty,@bob_settlement_key) 0x01',
                                    csv: 10
@@ -74,11 +72,11 @@ transition :bob_creates_settlement do
                                ]
 end
 
-transition :alice_broadcasts_funding_tx do
+transition :alice_broadcasts_setup_tx do
   # Alice signs the funding transaction and broadcasts it
-  update_script_sig for_tx: @funding_tx, at_index: 0, with_script_sig: 'sig:wpkh(@alice)'
-  broadcast @funding_tx
-  confirm transaction: @funding_tx, to: @bob
+  update_script_sig for_tx: @setup_tx, at_index: 0, with_script_sig: 'sig:wpkh(@alice)'
+  broadcast @setup_tx
+  confirm transaction: @setup_tx, to: @bob
 end
 
 transition :alice_signs_settlement do
@@ -94,8 +92,7 @@ transition :alice_broadcasts_settlement do
 end
 
 run_transitions :setup,
-                :alice_creates_funding,
                 :bob_creates_settlement,
-                :alice_broadcasts_funding_tx,
+                :alice_broadcasts_setup_tx,
                 :alice_signs_settlement,
                 :alice_broadcasts_settlement

--- a/lib/contracts/lightning/eltoo_onchain.rb
+++ b/lib/contracts/lightning/eltoo_onchain.rb
@@ -1,0 +1,101 @@
+# Copyright 2024 Kulpreet Singh
+#
+# This file is part of Bitcoin-DSL
+#
+# Bitcoin-DSL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bitcoin-DSL is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bitcoin-DSL. If not, see <https://www.gnu.org/licenses/>.
+
+# frozen_string_literal: false
+
+@alice = key :new
+@alice_update_key = key :new
+@alice_settlement_key = key :new
+
+@bob = key :new
+@bob_update_key = key :new
+@bob_settlement_key = key :new
+
+@update_script = %(
+OP_IF
+        2 @alice_settlement_key @bob_settlement_key 2 OP_CHECKMULTISIGVERIFY 10 OP_CSV
+OP_ELSE
+        2 @alice_update_key @bob_update_key 2 OP_CHECKMULTISIGVERIFY 10 OP_CSV
+OP_ENDIF
+)
+
+transition :setup do
+  extend_chain to: @alice, num_blocks: 101
+  @alice_funding_input_tx = spendable_coinbase_for @alice
+end
+
+transition :alice_creates_funding do
+  @funding_tx = transaction inputs: [
+                              {
+                                tx: @alice_funding_input_tx,
+                                vout: 0,
+                                script_sig: 'sig:_skip'
+                              }
+                            ],
+                            outputs: [
+                              {
+                                script: @update_script,
+                                # descriptor: 'wsh(multi(2,@alice_settlement_key,@bob_settlement_key))',
+                                amount: 49.999.sats
+                              }
+                            ]
+  assert_not_mempool_accept @funding_tx
+end
+
+transition :bob_creates_settlement do
+  # Bob signs a settlement transaction paying agreed amounts to Alice
+  @settlement_tx = transaction inputs: [
+                                 {
+                                   tx: @funding_tx,
+                                   vout: 0,
+                                   script_sig: 'sig:multi(_empty,@bob_settlement_key) 0x01',
+                                   csv: 10
+                                 }
+                               ],
+                               outputs: [
+                                 {
+                                   descriptor: 'wpkh(@alice)',
+                                   amount: 49.998.sats
+                                 }
+                               ]
+end
+
+transition :alice_broadcasts_funding_tx do
+  # Alice signs the funding transaction and broadcasts it
+  update_script_sig for_tx: @funding_tx, at_index: 0, with_script_sig: 'sig:wpkh(@alice)'
+  broadcast @funding_tx
+  confirm transaction: @funding_tx, to: @bob
+end
+
+transition :alice_signs_settlement do
+  update_script_sig for_tx: @settlement_tx, at_index: 0,
+                    with_script_sig: 'sig:multi(@alice_settlement_key,@bob_settlement_key) 0x01'
+  extend_chain num_blocks: 10
+  assert_mempool_accept @settlement_tx
+end
+
+transition :alice_broadcasts_settlement do
+  broadcast @settlement_tx
+  confirm transaction: @settlement_tx
+end
+
+run_transitions :setup,
+                :alice_creates_funding,
+                :bob_creates_settlement,
+                :alice_broadcasts_funding_tx,
+                :alice_signs_settlement,
+                :alice_broadcasts_settlement

--- a/lib/contracts/silent_payments.rb
+++ b/lib/contracts/silent_payments.rb
@@ -20,7 +20,7 @@
 # tag::silent-payment[]
 @sender_input_key = key :new # <1>
 @sender = key :new
-@receiver = key :new
+@receiver = key even_y: true # Generate a key with even y
 
 extend_chain to: @sender_input_key, num_blocks: 101
 

--- a/lib/contracts/taproot/scriptpath_spend.rb
+++ b/lib/contracts/taproot/scriptpath_spend.rb
@@ -18,7 +18,6 @@
 # frozen_string_literal: false
 
 # Generate new keys
-Bitcoin::Node::Configuration.new(network: :regtest)
 @alice = key wif: 'cNtZwU6mYnUXDJtPqfyEaRsZuNy6C5PCZHY16xbps85HvRSn9KqE'
 @bob = key wif: 'cMyDpdQkC1qRfWYNQHXawUwzEmXyFjv7PYw2EqYFRnhXhBs4bXt9'
 @carol = key wif: 'cRCuYhzDcPPCjfVZPzSiuRAsXUgivChpz5xEfeXPRAi2EDnuHymz'
@@ -33,17 +32,17 @@ transition :create_input_tx do
 
   # tag::taproot_tx[]
   @taproot_output_tx = transaction inputs: [
-                                      { tx: @coinbase_tx,
-                                        vout: 0,
-                                        script_sig: 'sig:wpkh(@alice)' }
-                                    ],
-                                    outputs: [
-                                      {
-                                        taproot: { internal_key: @bob, # <1>
-                                                   leaves: ['pk(@carol)', 'pk(@alice)'] }, # <2>
-                                        amount: 49.999.sats
-                                      }
-                                    ]
+                                     { tx: @coinbase_tx,
+                                       vout: 0,
+                                       script_sig: 'sig:wpkh(@alice)' }
+                                   ],
+                                   outputs: [
+                                     {
+                                       taproot: { internal_key: @bob, # <1>
+                                                  leaves: ['pk(@carol)', 'pk(@alice)'] }, # <2>
+                                       amount: 49.999.sats
+                                     }
+                                   ]
   # end::taproot_tx[]
 
   broadcast @taproot_output_tx

--- a/lib/dsl/key.rb
+++ b/lib/dsl/key.rb
@@ -23,20 +23,32 @@ require_relative './group_operations'
 module Key
   include GroupOperations
 
+  def self.included(_mod)
+    Bitcoin::Node::Configuration.new(network: :regtest)
+  end
+
   def key(params = {})
     if params.is_a?(Hash)
-      if params.include?(:wif)
-        Bitcoin::Key.from_wif params[:wif]
-      elsif params.include?(:from_point)
-        Bitcoin::Key.from_point params[:from_point]
-      elsif params.include?(:even_y)
-        generated = Bitcoin::Key.generate
-        generated = Bitcoin::Key.generate until generated.to_point.has_even_y?
-        generated
-      end
+      from_params(params)
     else
       Bitcoin::Key.generate
     end
+  end
+
+  def from_params(params)
+    if params.include?(:wif)
+      Bitcoin::Key.from_wif params[:wif]
+    elsif params.include?(:from_point)
+      Bitcoin::Key.from_point params[:from_point]
+    elsif params.include?(:even_y)
+      even_y
+    end
+  end
+
+  def even_y
+    generated = Bitcoin::Key.generate
+    generated = Bitcoin::Key.generate until generated.to_point.has_even_y?
+    generated
   end
 
   def point_from(key)

--- a/lib/dsl/key.rb
+++ b/lib/dsl/key.rb
@@ -29,6 +29,10 @@ module Key
         Bitcoin::Key.from_wif params[:wif]
       elsif params.include?(:from_point)
         Bitcoin::Key.from_point params[:from_point]
+      elsif params.include?(:even_y)
+        generated = Bitcoin::Key.generate
+        generated = Bitcoin::Key.generate until generated.to_point.has_even_y?
+        generated
       end
     else
       Bitcoin::Key.generate

--- a/lib/runner.rb
+++ b/lib/runner.rb
@@ -31,7 +31,6 @@ class Runner
   include DSL
 
   def initialize
-    Bitcoin::Node::Configuration.new(network: :regtest)
     @txid_signers = {}
     @witness_scripts = {}
     @taproot_details = {}

--- a/lib/runner.rb
+++ b/lib/runner.rb
@@ -31,6 +31,7 @@ class Runner
   include DSL
 
   def initialize
+    Bitcoin::Node::Configuration.new(network: :regtest)
     @txid_signers = {}
     @witness_scripts = {}
     @taproot_details = {}

--- a/spec/dsl/key_spec.rb
+++ b/spec/dsl/key_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Key do
   include Key
 
   before(:context) do
-    @key = key wif: 'KztsFfy2uzazyo2zLgXneWH1U97Rv2dAiRQn74tR7qGMMYAjfGhD'
+    @key = key wif: 'cT3dEHwpi1EWbRxiUQaPYUYmeHTq2hSJRA4j81WoM5hiq3ZM33UK'
     @message = Bitcoin.sha256('message')
   end
 

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Runner.instance do
 
   describe 'Running contracts with CSV and CLTV' do
     it_behaves_like 'script evaluation', './lib/contracts/csv.rb'
+    it_behaves_like 'script evaluation', './lib/contracts/conditional.rb'
     it_behaves_like 'script evaluation', './lib/contracts/cltv.rb'
   end
 

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -76,4 +76,8 @@ RSpec.describe Runner.instance do
     it_behaves_like 'script evaluation', './lib/contracts/taproot/keypath_spend.rb'
     it_behaves_like 'script evaluation', './lib/contracts/taproot/scriptpath_spend.rb'
   end
+
+  describe 'silent payment' do
+    it_behaves_like 'script evaluation', './lib/contracts/silent_payments.rb'
+  end
 end


### PR DESCRIPTION
- Add eltoo example
- Add support for even y keys
- Use even y key as receiver in silent payments example
- refactor key generation method
- set network in Key module, not just when initialising runtime