### PR TITLE
Lock IRB version used from jupyterlab 

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,6 +4,7 @@ name: Create and publish a Docker image
 on:
   push:
     branches: ['release']
+  workflow_dispatch:
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -49,8 +49,8 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+          # cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          # cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
       - name: Run rake spec
         run: docker run ${{ env.DOCKER_METADATA_OUTPUT_TAGS }} /bitcoin-dsl/bin/rake spec
       - name: Push Docker image
@@ -60,6 +60,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+          # cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          # cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,6 @@ ENV JUPYTER_PORT=8888
 EXPOSE $JUPYTER_PORT
 
 # iruby setup
-RUN git clone -b dsl-binding --depth=1 https://github.com/pool2win/iruby.git
-RUN cd iruby && gem build iruby.gemspec && gem install iruby-0.7.4.gem
 COPY jupyter/kernel.json /root/.local/share/jupyter/kernels/ruby/kernel.json
 # iruby setup end
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN cd miniscript-cli && cargo install --path .
 
 # # Install RVM, Ruby, and Bundler
 COPY Gemfile Gemfile
-RUN gem install bundler && \
+RUN gem install bundler:2.5.5 && \
     bundle install && \
     bundle binstubs --all
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,5 @@ gem "rspec", "~> 3.13", :group => :development
 
 gem "solargraph", "~> 0.50.0", :group => :development
 
-gem "iruby", "~> 0.7.4", :group => :development
+gem "irb", "1.12.0"
+gem 'iruby', github: 'pool2win/iruby', branch: 'dsl-binding'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,10 +19,23 @@ GIT
       siphash
       thor
 
+GIT
+  remote: https://github.com/pool2win/iruby.git
+  revision: 765e3d996c1fb14a9f96919592c6d18435ac6447
+  branch: dsl-binding
+  specs:
+    iruby (0.7.4)
+      data_uri (~> 0.1)
+      ffi-rzmq
+      irb
+      mime-types (>= 3.3.1)
+      multi_json (~> 1.11)
+      native-package-installer
+
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3.2)
+    activesupport (7.1.3.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -39,7 +52,7 @@ GEM
     bech32 (1.4.2)
       thor (>= 1.1.0)
     benchmark (0.3.0)
-    bigdecimal (3.1.7)
+    bigdecimal (3.1.8)
     bip-schnorr (0.7.0)
       ecdsa_ext (~> 0.5.0)
     concurrent-ruby (1.2.3)
@@ -59,20 +72,13 @@ GEM
       ffi-rzmq-core (>= 1.0.7)
     ffi-rzmq-core (1.0.7)
       ffi
-    i18n (1.14.4)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     iniparse (1.5.0)
     io-console (0.7.2)
     irb (1.12.0)
       rdoc
       reline (>= 0.4.2)
-    iruby (0.7.4)
-      data_uri (~> 0.1)
-      ffi-rzmq
-      irb
-      mime-types (>= 3.3.1)
-      multi_json (~> 1.11)
-      native-package-installer
     jaro_winkler (1.5.6)
     json (2.7.2)
     json_pure (2.7.2)
@@ -84,20 +90,16 @@ GEM
     leb128 (1.0.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.0305)
-    mini_portile2 (2.8.6)
-    minitest (5.22.3)
+    mime-types-data (3.2024.0507)
+    minitest (5.23.0)
     multi_json (1.15.0)
     murmurhash3 (0.1.7)
     mutex_m (0.2.0)
     native-package-installer (1.1.9)
-    nokogiri (1.16.4)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
-    nokogiri (1.16.4-x86_64-linux)
+    nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
     parallel (1.24.0)
-    parser (3.3.0.5)
+    parser (3.3.1.0)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.3)
@@ -109,12 +111,13 @@ GEM
     rbs (2.8.4)
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
-    regexp_parser (2.9.0)
-    reline (0.5.1)
+    regexp_parser (2.9.2)
+    reline (0.5.7)
       io-console (~> 0.5)
     reverse_markdown (2.1.1)
       nokogiri
-    rexml (3.2.6)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -124,11 +127,11 @@ GEM
     rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.0)
+    rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    rubocop (1.63.1)
+    rubocop (1.63.5)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -139,8 +142,8 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.2)
-      parser (>= 3.3.0.4)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
     siphash (0.0.1)
     solargraph (0.50.0)
@@ -160,6 +163,7 @@ GEM
       tilt (~> 2.0)
       yard (~> 0.9, >= 0.9.24)
     stringio (3.1.0)
+    strscan (3.1.0)
     test-unit (3.6.2)
       power_assert
     thor (1.3.1)
@@ -170,13 +174,13 @@ GEM
     yard (0.9.36)
 
 PLATFORMS
-  ruby
   x86_64-linux
 
 DEPENDENCIES
   activesupport (~> 7.1)
   bitcoinrb!
-  iruby (~> 0.7.4)
+  irb (= 1.12.0)
+  iruby!
   rake (~> 13.1)
   rspec (~> 3.13)
   rubocop (~> 1.62)
@@ -184,4 +188,4 @@ DEPENDENCIES
   test-unit (~> 3.6)
 
 BUNDLED WITH
-   2.5.5
+   2.2.3

--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 x-common:
   &common
   ports:


### PR DESCRIPTION
IRB's new releases are not compatible with our extensions to iruby. We will need to fix our iruby fork, but for the moment, we lock down irb version so that our notebooks work as expected.